### PR TITLE
fix: read full body from requests

### DIFF
--- a/lib/ampule.py
+++ b/lib/ampule.py
@@ -50,8 +50,9 @@ def __read_request(client):
     message = bytearray()
     hdr_end = -1
     content_length = 0
+    last_data = time.monotonic()
 
-    for _ in range(30):
+    while time.monotonic() - last_data < 2.0:
         try:
             num_received = client.recv_into(_recv_buffer)
             if num_received == 0:
@@ -62,6 +63,7 @@ def __read_request(client):
                     break
             if num_received > 0:
                 message.extend(_recv_buffer[:num_received])
+                last_data = time.monotonic()
             if hdr_end < 0:
                 hdr_end = message.find(b'\r\n\r\n')
                 if hdr_end >= 0:


### PR DESCRIPTION
Read until the full Content-Length body arrives, bounded by an idle timeout rather than a fixed iteration count: a multi-KB POST split across TCP segments (with EAGAIN waits between them) used to exhaust a 30-loop cap and truncate the body. Reset the clock whenever bytes arrive.

Makes saving files via the file manager more reliable, especially for larger files.