### PR TITLE
fix: improve app lifecycle on launch and teardown

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 
-import sys, wifi, socketpool, time, os, json, microcontroller, ampule
+import sys, wifi, socketpool, time, os, json, microcontroller, ampule, gc
 import load_settings
 import digitalio, board
 import adafruit_connection_manager, adafruit_requests
@@ -106,39 +106,38 @@ def webinterface(request):
 def initialize_app():
     global autostart
     ampule_routes_backup = ampule.routes.copy()
-    
-    try: 
+    palette_backup = [palette[i] for i in range(12)]  # restored on exit
+
+    try:
         clearscreen(lines=True)
         pprint(f"Starting {load_settings.app_running}...")
         os.chdir(load_settings.app_running)
         time.sleep(0.5)
+        ampule.routes.clear()  # apps start with a clean route table
         import __init__
-    except Exception as e: 
-        #pprint(f"{load_settings.app_running} crashed.")
-        try: pprint(f"{e}")
-        except: pass
+    except Exception as e:
         print(f"{e}")
         settings["autostart"] = 0
-    finally: 
-        palette[0] = (0)
+    finally:
+        for i, backup in enumerate(palette_backup):
+            palette[i] = backup
         try: microcontroller.cpu.frequency = 160000000
         except: pass
         autostart = False
         ampule.routes = ampule_routes_backup.copy()
-        try: 
+        try:
             for codefile in os.listdir():
-                try: del sys.modules[codefile.replace(".py", "")]
+                try: del sys.modules[codefile.rsplit(".", 1)[0]]
                 except: pass
-            #del sys.modules["__init__"]
-            #del sys.modules["code"]
         except: pass
+        gc.collect()  # reclaim the exited app's bitmaps so the next launch is clean
         display.root_group = rf_group
         os.chdir("/")
-        clearscreen()
+        clearscreen(lines=True)  # zero the window so a buggy app leaves no artifacts
         show_logo()
-        _wifi_address = str(wifi.radio.ipv4_address) if wifi.radio.ipv4_address else "OFFLINE"
-        pprint(_wifi_address)
-        pprint("Select app:")
+        _wifi_address = f"IP: {wifi.radio.ipv4_address}" if wifi.radio.ipv4_address else "OFFLINE"
+        pprint(_wifi_address, line=1)
+        pprint("Select app:", line=2)
         show_first_app()
         return False
 

--- a/system_prompt.md
+++ b/system_prompt.md
@@ -38,18 +38,10 @@ Serial console: Connect via USB serial (default baud 115200).
 == CREATING APPS ==
 NEVER name an app after a Python module (time, json, os, sys, math, etc.)!
 
-__init__.py TEMPLATE (MUST be exactly this):
+__init__.py TEMPLATE:
 ```
 from __main__ import *
-ampule.routes.clear()
-_sp = []
-for i in range(12):
-    try: _sp.append(palette[i])
-    except: _sp.append(0)
 import code
-for i in range(12):
-    try: palette[i] = _sp[i]
-    except: pass
 ```
 
 code.py TEMPLATE:


### PR DESCRIPTION
Centralize cleanup in `initialize_app` so individual apps don't each have to, and so a buggy app can't leave shared state broken:

- restore palette slots 0-11 on exit (an app can no longer leave the shared palette altered for the selector or the next app)
- clear ampule routes on launch (`ampule.routes.clear()`)
- `gc.collect()` on teardown to free the exited app's bitmaps before the next launch
- strip any extension when removing app modules from `sys.modules`, so compiled (`.mpy`) apps tear down too (fixes apps only starting once)
- clear the window on exit so a buggy app leaves no artifacts (`lines=True`)
- draw the IP and "Select app:" on fixed lines so reconnect churn can't evict the IP from the scrolling line buffer
- update `system_prompt.md` to not require setup/teardown per app

---

I had a bunch of issues managing app lifecycles on both my own apps I'm developing and existing ones. Issues like breaking palette entries so colors on main screen are wrong, IP not showing after app closing, compiled apps (`.mpy`) not clearing and apps like `rain`, `paint` and `fireworks` not doing proper cleanup.

By moving this logic of garbage collecting and palette restoring to the main lifecycle each app no longer has to think about this so I removed it from the template as well.