### PR TITLE
chore: remove faulty docs about `mpy-cross`

### DIFF
--- a/apps/lastfm/README.md
+++ b/apps/lastfm/README.md
@@ -12,14 +12,6 @@ account][create-api-account].
 Once generated, start the app via the UI and fill in your Last.fm username and
 the generated API key.
 
-## Development notes
-
-The code in this path is the human-readable code. It's compiled to `.mpy`
-bytecode with [`mpy-cross`][mpy-cross] and copied to `apps/lastfm` to minimize
-size on device; the HTML is minified for the same reason. See `build.py` in
-`tools` for more info.
-
 [Last.fm]: https://www.last.fm
 [create-api-account]: https://www.last.fm/api/account/create
-[mpy-cross]: https://github.com/adafruit/circuitpython/tree/main/mpy-cross
 [track]: https://www.last.fm/about/trackmymusic


### PR DESCRIPTION
This was never removed when deciding not to use a separate version for the distributed app and the source code.