### PR TITLE
Add option to show line ID in multi-stop list mode

### DIFF
--- a/apps/departures/createhtml.py
+++ b/apps/departures/createhtml.py
@@ -499,6 +499,10 @@ def huvudsidan(request):
         varinit.settings["clock_row_color"] = v if v in ("white", "yellow", "red", "green", "blue") else "white"
         functions.switch(_screen=False)
         return (200, {}, "")
+    elif "multi_line_id" in request.params:
+        varinit.settings["multi_line_id"] = 1 - int(varinit.settings.get("multi_line_id", 0))
+        functions.switch(_screen=False)
+        return (200, {}, "")
     elif "dest_scroll" in request.params:
         varinit.settings["dest_scroll"] = 1 - int(varinit.settings.get("dest_scroll", 0))
         functions.switch(_screen=False)

--- a/apps/departures/createhtml.py
+++ b/apps/departures/createhtml.py
@@ -499,8 +499,8 @@ def huvudsidan(request):
         varinit.settings["clock_row_color"] = v if v in ("white", "yellow", "red", "green", "blue") else "white"
         functions.switch(_screen=False)
         return (200, {}, "")
-    elif "multi_line_id" in request.params:
-        varinit.settings["multi_line_id"] = 1 - int(varinit.settings.get("multi_line_id", 0))
+    elif "multi_station_line_id" in request.params:
+        varinit.settings["multi_station_line_id"] = 1 - int(varinit.settings.get("multi_station_line_id", 0))
         functions.switch(_screen=False)
         return (200, {}, "")
     elif "dest_scroll" in request.params:

--- a/apps/departures/dicts.py
+++ b/apps/departures/dicts.py
@@ -179,6 +179,7 @@ settingstxt = {"password": "none",
             "clock_row_position":"bottom",
             "clock_row_align":"left",
             "clock_row_color":"white",
+            "multi_line_id":0,
             "dest_scroll":0,
             
             "clocktime": 0, 

--- a/apps/departures/dicts.py
+++ b/apps/departures/dicts.py
@@ -179,7 +179,7 @@ settingstxt = {"password": "none",
             "clock_row_position":"bottom",
             "clock_row_align":"left",
             "clock_row_color":"white",
-            "multi_line_id":0,
+            "multi_station_line_id":0,
             "dest_scroll":0,
             
             "clocktime": 0, 

--- a/apps/departures/functions.py
+++ b/apps/departures/functions.py
@@ -913,6 +913,10 @@ def list_mode(mini=False, half=False):
     if varinit.if_long > 128: version_delay(slowdown=1)
     large_list = not mini and not half and not varinit.rotated and int(varinit.settings.get("large_list", 0))
     xs_line_id = varinit.display.width <= 64 and not varinit.rotated and int(varinit.settings.get("xs_line_id", 0))
+    multi_line_id = half and not varinit.rotated and varinit.display.width > 64 \
+                    and int(varinit.settings.get("multi_line_id", 0)) and int(varinit.settings["line_length"])
+    _show_line = not varinit.rotated and (varinit.display.width > 64 or xs_line_id) \
+                 and (not half or multi_line_id)
     varinit.currentfont = 1
     if mini: varinit.currentfont = 2
     elif large_list: varinit.currentfont = 0
@@ -1001,13 +1005,15 @@ def list_mode(mini=False, half=False):
                 #    return time.monotonic()
                 #if not half: return time.monotonic() - varinit.updatedelay + 2
         
-            if large_list and isinstance(trainlist, list):
+            if (large_list or multi_line_id) and isinstance(trainlist, list):
                 _max_lw = 0
                 for _a in trainlist:
                     if isinstance(_a, list) and len(_a) > 1:
-                        _w = strlen(_a[1][:varinit.settings["line_length"]])
+                        _lid = "1(1(" if (_a[1] == "11" and not varinit.settings["clocktime"]) else _a[1]
+                        _w = strlen(_lid[:varinit.settings["line_length"]])
                         if _w > _max_lw: _max_lw = _w
-                line_col = _max_lw + 6
+                if large_list: line_col = _max_lw + 6
+                else: line_col = _max_lw + 2 if _max_lw else 0
             else:
                 line_col = 0
 
@@ -1080,6 +1086,10 @@ def list_mode(mini=False, half=False):
                         _max_px = 64 - strlen(all[3]) - 1
                         while len(all[2]) > 0 and strlen(all[2]) > max(0, _max_px):
                             all[2] = all[2][:-1]
+                    elif multi_line_id:
+                        _max_px = 64 - strlen(all[3]) - line_col - 1
+                        while len(all[2]) > 0 and strlen(all[2]) > max(0, _max_px):
+                            all[2] = all[2][:-1]
                     else:
                         all[2] = all[2][:15 - len(varinit.settings["mins"])]
                         if varinit.settings["clocktime"]:
@@ -1126,7 +1136,7 @@ def list_mode(mini=False, half=False):
                         added_space = (_xs_max_lw + 2) * "("
                 elif mini:
                     added_space = varinit.settings["line_length"] * "(((("
-                    if half: added_space = ""
+                    if half: added_space = line_col * "(" if multi_line_id else ""
                 else: added_space = varinit.settings["line_length"] * "(((((("
                 if not varinit.settings["line_length"]:
                     added_space = ""
@@ -1168,7 +1178,7 @@ def list_mode(mini=False, half=False):
                         }
                         renderstring(multiple_offset + minsleft, 100+x, 0, 0, inv, mini=mini,
                                      sys_msg=min_color, target_bmp=varinit.overlay_bmp)
-                        if not half and not varinit.rotated and (varinit.display.width > 64 or xs_line_id):
+                        if _show_line:
                             renderstring(multiple_offset + line, 100+x, 0, 0, inv, mini=mini,
                                          sys_msg=lin_color, target_bmp=varinit.overlay_bmp)
                         varinit.overlay_tg.y = extrarow
@@ -1176,7 +1186,7 @@ def list_mode(mini=False, half=False):
                     else:
                         renderstring(multiple_offset + minsleft, 100+x, 0, 0, inv, mini=mini, sys_msg=min_color)
                         renderstring(multiple_offset + added_space + dest, 100+x, 0, 0, inv, mini=mini, sys_msg=(clock_color if is_clock_row else False))
-                        if not half and not varinit.rotated and (varinit.display.width > 64 or xs_line_id):
+                        if _show_line:
                             renderstring(multiple_offset + line, 100+x, 0, 0, inv, mini=mini, sys_msg=lin_color)
                     if x > varinit.if_tall // 8 - 1: continue
             num -= 1

--- a/apps/departures/functions.py
+++ b/apps/departures/functions.py
@@ -913,10 +913,10 @@ def list_mode(mini=False, half=False):
     if varinit.if_long > 128: version_delay(slowdown=1)
     large_list = not mini and not half and not varinit.rotated and int(varinit.settings.get("large_list", 0))
     xs_line_id = varinit.display.width <= 64 and not varinit.rotated and int(varinit.settings.get("xs_line_id", 0))
-    multi_line_id = half and not varinit.rotated and varinit.display.width > 64 \
-                    and int(varinit.settings.get("multi_line_id", 0)) and int(varinit.settings["line_length"])
+    multi_station_line_id = half and not varinit.rotated and varinit.display.width > 64 \
+                    and int(varinit.settings.get("multi_station_line_id", 0)) and int(varinit.settings["line_length"])
     _show_line = not varinit.rotated and (varinit.display.width > 64 or xs_line_id) \
-                 and (not half or multi_line_id)
+                 and (not half or multi_station_line_id)
     varinit.currentfont = 1
     if mini: varinit.currentfont = 2
     elif large_list: varinit.currentfont = 0
@@ -1005,7 +1005,7 @@ def list_mode(mini=False, half=False):
                 #    return time.monotonic()
                 #if not half: return time.monotonic() - varinit.updatedelay + 2
         
-            if (large_list or multi_line_id) and isinstance(trainlist, list):
+            if (large_list or multi_station_line_id) and isinstance(trainlist, list):
                 _max_lw = 0
                 for _a in trainlist:
                     if isinstance(_a, list) and len(_a) > 1:
@@ -1086,7 +1086,7 @@ def list_mode(mini=False, half=False):
                         _max_px = 64 - strlen(all[3]) - 1
                         while len(all[2]) > 0 and strlen(all[2]) > max(0, _max_px):
                             all[2] = all[2][:-1]
-                    elif multi_line_id:
+                    elif multi_station_line_id:
                         _max_px = 64 - strlen(all[3]) - line_col - 1
                         while len(all[2]) > 0 and strlen(all[2]) > max(0, _max_px):
                             all[2] = all[2][:-1]
@@ -1136,7 +1136,7 @@ def list_mode(mini=False, half=False):
                         added_space = (_xs_max_lw + 2) * "("
                 elif mini:
                     added_space = varinit.settings["line_length"] * "(((("
-                    if half: added_space = line_col * "(" if multi_line_id else ""
+                    if half: added_space = line_col * "(" if multi_station_line_id else ""
                 else: added_space = varinit.settings["line_length"] * "(((((("
                 if not varinit.settings["line_length"]:
                     added_space = ""

--- a/apps/departures/web.py
+++ b/apps/departures/web.py
@@ -152,7 +152,7 @@ PAGE_TPL = """<!DOCTYPE html>
 </table>
 {RT_INDICATOR_CHK}
 {XS_LINE_ID_CHK}
-{MULTI_LINE_ID_CHK}
+{MULTI_STATION_LINE_ID_CHK}
 {LISTCOLOR_CHK}
 {LISTCOLOR_TIME_CHK}
 {DEST_SCROLL_CHK}
@@ -446,7 +446,7 @@ def html():
         + _opt("blue", s.get("clock_row_color", "white"), "Blue")
         + '</select></td></tr>'
     )
-    multi_line_id_chk = _chk("MULTI_LINE_ID", s.get("multi_line_id", 0), "/?multi_line_id=switch", "Show line ID in multi-line mode") if if_long > 64 else ""
+    multi_station_line_id_chk = _chk("MULTI_STATION_LINE_ID", s.get("multi_station_line_id", 0), "/?multi_station_line_id=switch", "Show line ID in multi-line list mode") if if_long > 64 else ""
     # dest_scroll
     dest_scroll_html = _chk("DEST_SCROLL", s.get("dest_scroll", 0), "/?dest_scroll=switch", "Scroll long destination names")
 
@@ -510,7 +510,7 @@ def html():
         "LISTCOLOR_CHK": listcolor_html,
         "LISTCOLOR_TIME_CHK": listcolor_time_html,
         "CLOCK_ROW_HTML": clock_row_html,
-        "MULTI_LINE_ID_CHK": multi_line_id_chk,
+        "MULTI_STATION_LINE_ID_CHK": multi_station_line_id_chk,
         "T_LINE_LENGTH": T["line_length"],
         "T_LINE_LENGTH_HELP": "Most line numbers are 1-2 characters, so this often looks the same until a line uses a longer code.",
         "LINE_LENGTH_VAL": str(s["line_length"]),

--- a/apps/departures/web.py
+++ b/apps/departures/web.py
@@ -140,6 +140,7 @@ PAGE_TPL = """<!DOCTYPE html>
 <tr><td><b>{T_TONE}</b></td><td><div style="display:flex;gap:10px">{TONE_SWATCHES}</div></td></tr>
 {FONT_SIZE_ROW}
 {CLOCK_ROW_HTML}
+{MULTI_LINE_ID_ROW}
 <tr><td><b>Timer</b></td><td><button type="button" class="btn btn-sm" onclick="location.href='/?timer=set'">&#8987; Configure</button></td></tr>
 <tr><td><b>{T_ROTATION}</b></td><td><button type="button" class="btn btn-sm" data-u="/?rotate=1">&#128260; 90&deg;</button></td></tr>
 <tr><td><b>{T_POWER}</b></td><td><input type="text" id="power" class="form-control" style="width:80px;display:inline" placeholder="{POWER_VAL}" data-p="power" data-e="blur"></td></tr>
@@ -445,6 +446,7 @@ def html():
         + _opt("blue", s.get("clock_row_color", "white"), "Blue")
         + '</select></td></tr>'
     )
+    multi_line_id_row = '<tr><td><b>Multi line ID</b></td><td>' + _chk("MULTI_LINE_ID", s.get("multi_line_id", 0), "/?multi_line_id=switch", "Show line ID") + '</td></tr>' if if_long > 64 else ""
     # dest_scroll
     dest_scroll_html = _chk("DEST_SCROLL", s.get("dest_scroll", 0), "/?dest_scroll=switch", "Scroll long destination names")
 
@@ -508,6 +510,7 @@ def html():
         "LISTCOLOR_CHK": listcolor_html,
         "LISTCOLOR_TIME_CHK": listcolor_time_html,
         "CLOCK_ROW_HTML": clock_row_html,
+        "MULTI_LINE_ID_ROW": multi_line_id_row,
         "T_LINE_LENGTH": T["line_length"],
         "T_LINE_LENGTH_HELP": "Most line numbers are 1-2 characters, so this often looks the same until a line uses a longer code.",
         "LINE_LENGTH_VAL": str(s["line_length"]),

--- a/apps/departures/web.py
+++ b/apps/departures/web.py
@@ -140,7 +140,6 @@ PAGE_TPL = """<!DOCTYPE html>
 <tr><td><b>{T_TONE}</b></td><td><div style="display:flex;gap:10px">{TONE_SWATCHES}</div></td></tr>
 {FONT_SIZE_ROW}
 {CLOCK_ROW_HTML}
-{MULTI_LINE_ID_ROW}
 <tr><td><b>Timer</b></td><td><button type="button" class="btn btn-sm" onclick="location.href='/?timer=set'">&#8987; Configure</button></td></tr>
 <tr><td><b>{T_ROTATION}</b></td><td><button type="button" class="btn btn-sm" data-u="/?rotate=1">&#128260; 90&deg;</button></td></tr>
 <tr><td><b>{T_POWER}</b></td><td><input type="text" id="power" class="form-control" style="width:80px;display:inline" placeholder="{POWER_VAL}" data-p="power" data-e="blur"></td></tr>
@@ -153,6 +152,7 @@ PAGE_TPL = """<!DOCTYPE html>
 </table>
 {RT_INDICATOR_CHK}
 {XS_LINE_ID_CHK}
+{MULTI_LINE_ID_CHK}
 {LISTCOLOR_CHK}
 {LISTCOLOR_TIME_CHK}
 {DEST_SCROLL_CHK}
@@ -446,7 +446,7 @@ def html():
         + _opt("blue", s.get("clock_row_color", "white"), "Blue")
         + '</select></td></tr>'
     )
-    multi_line_id_row = '<tr><td><b>Multi line ID</b></td><td>' + _chk("MULTI_LINE_ID", s.get("multi_line_id", 0), "/?multi_line_id=switch", "Show line ID") + '</td></tr>' if if_long > 64 else ""
+    multi_line_id_chk = _chk("MULTI_LINE_ID", s.get("multi_line_id", 0), "/?multi_line_id=switch", "Show line ID in multi-line mode") if if_long > 64 else ""
     # dest_scroll
     dest_scroll_html = _chk("DEST_SCROLL", s.get("dest_scroll", 0), "/?dest_scroll=switch", "Scroll long destination names")
 
@@ -510,7 +510,7 @@ def html():
         "LISTCOLOR_CHK": listcolor_html,
         "LISTCOLOR_TIME_CHK": listcolor_time_html,
         "CLOCK_ROW_HTML": clock_row_html,
-        "MULTI_LINE_ID_ROW": multi_line_id_row,
+        "MULTI_LINE_ID_CHK": multi_line_id_chk,
         "T_LINE_LENGTH": T["line_length"],
         "T_LINE_LENGTH_HELP": "Most line numbers are 1-2 characters, so this often looks the same until a line uses a longer code.",
         "LINE_LENGTH_VAL": str(s["line_length"]),


### PR DESCRIPTION
The line ID column was suppressed whenever list mode split the screen into per-station panes, so a 2- or 3-pane layout could never show e.g. bus 824.

Adds a "multi_line_id" setting that brings the column back inside the panes. The column is auto-width per pane, sized to the widest line ID actually present, since a 64px pane has no room to waste. Destination trimming in panes switches from a character count to pixel-based fitting when the option is on; behaviour is unchanged when it is off.