### PR TITLE
fix: don't show minute column for clock

### DIFF
--- a/apps/departures/functions.py
+++ b/apps/departures/functions.py
@@ -961,7 +961,8 @@ def list_mode(mini=False, half=False):
     else:
         for i in range(_r):
             print("Fetching: ", i+1)
-            varinit.traindata[i+1] = apply_clock_row(reformat_data(get_departure(num = str(i+1))))
+            _data = reformat_data(get_departure(num = str(i+1)))
+            varinit.traindata[i+1] = apply_clock_row(_data) if i == 0 else _data
             if not half or i+1 == _r: break
         
     
@@ -1035,8 +1036,11 @@ def list_mode(mini=False, half=False):
                     if strlen(all[3]) < _mins_ref_w:
                         all[3] = (_mins_ref_w - strlen(all[3])) * "(" + all[3]
 
-                if_not_clocktime = varinit.settings["mins"] if all[3] \
-                and not varinit.settings["clocktime"] and not is_clock_row else ""
+                if_not_clocktime = (
+                    varinit.settings["mins"]
+                    if all[3] and not varinit.settings["clocktime"] and not is_clock_row
+                    else ""
+                )
 
                 all[3] += if_not_clocktime
 
@@ -1065,10 +1069,15 @@ def list_mode(mini=False, half=False):
                         all[2] = abbreviate_dest(all[2], _max_px)
                         while len(all[2]) > 0 and strlen(all[2]) > max(0, _max_px):
                             all[2] = all[2][:-1]
-                if half: 
-                    all[2] = all[2][:15 - len(varinit.settings["mins"])]
-                    if varinit.settings["clocktime"]:
-                        all[2] = all[2][:11]
+                if half:
+                    if is_clock_row:
+                        _max_px = 64 - strlen(all[3]) - 1
+                        while len(all[2]) > 0 and strlen(all[2]) > max(0, _max_px):
+                            all[2] = all[2][:-1]
+                    else:
+                        all[2] = all[2][:15 - len(varinit.settings["mins"])]
+                        if varinit.settings["clocktime"]:
+                            all[2] = all[2][:11]
                 mins = all[2]
                 if not varinit.settings["clocktime"]: all[1] = "1(1(" if all[1] == "11" else all[1]
 

--- a/apps/departures/functions.py
+++ b/apps/departures/functions.py
@@ -1036,7 +1036,7 @@ def list_mode(mini=False, half=False):
                         all[3] = (_mins_ref_w - strlen(all[3])) * "(" + all[3]
 
                 if_not_clocktime = varinit.settings["mins"] if all[3] \
-                and not varinit.settings["clocktime"] else ""
+                and not varinit.settings["clocktime"] and not is_clock_row else ""
 
                 all[3] += if_not_clocktime
 


### PR DESCRIPTION
- When using "Show date/time instead of a departure", the row still shows the "min" to the right. This removes that on the clock row.
- The clock was displayed in all columns when using multiple columns (multiple lines). This will only show the clock in the first column
- Allocation of space to draw on always removed pixes in place for "x mins" or "HH:MM", but we never draw this on a clock row so it allows for the full 64px budget making it possible to render both date and time on a 128px device with two columns.
