### PR TITLE
fix: use full display with for multi stations

### DIFF
--- a/apps/departures/createhtml.py
+++ b/apps/departures/createhtml.py
@@ -285,10 +285,18 @@ def huvudsidan(request):
         
         if request.params["width"] == "xs": varinit.settings["long"] = -1
         elif request.params["width"] == "x": varinit.settings["long"] = 0
-        elif request.params["width"] == "xl": varinit.settings["long"] = 1
+        elif request.params["width"] == "xl":
+            varinit.settings["long"] = 1
+            # Station 3 defaults to an inactive sentinel (siteid "00"), so
+            # switching a fresh setup to 3 columns would otherwise show an
+            # unconfigured, empty third station. Seed it from station 1
+            # (already configured on any device in real use) instead.
+            station_3 = varinit.settings["stations"]["3"]
+            if station_3["siteid"] in ("00", "0", "000", "") or not station_3["operator"]:
+                varinit.settings["stations"]["3"] = dict(varinit.settings["stations"]["1"])
         else: return (200, {}, mkhtml())
-        functions.savesettings()
-        functions.reset()
+
+        functions.switch(_screen=False)
         return (200, {}, mkhtml())
 
     elif "checknet" in request.params: 

--- a/apps/departures/functions.py
+++ b/apps/departures/functions.py
@@ -960,7 +960,16 @@ def list_mode(mini=False, half=False):
             if varinit.settings["long"] == 1: _r = 3
         else: _r = 1
     except: pass
-    
+
+    # Each station gets an equal share of the physical display, so a device
+    # with spare panels (e.g. the XL's three panels showing only 2 stations)
+    # spreads its stations across the full width.
+    # COL_MARGIN keeps a small gap at the column's edges; the rest
+    # of the column is filled by the natural gap between the destination
+    # and the time, so a wider column just reads as more breathing room.
+    col_w = varinit.if_long // _r
+    COL_MARGIN = 2
+
     merge_list_mode = int(varinit.settings["multiple"]) and varinit.display.width <= 64 and not varinit.rotated
     if merge_list_mode:
         print("Fetching merged stops")
@@ -1078,7 +1087,7 @@ def list_mode(mini=False, half=False):
                         while len(all[2]) > 0 and strlen(all[2]) > max(0, _max_px):
                             all[2] = all[2][:-1]
                     elif multi_station_line_id:
-                        _max_px = 64 - strlen(all[3]) - line_col - 1
+                        _max_px = col_w - (COL_MARGIN * 2) - strlen(all[3]) - line_col - 1
                         while len(all[2]) > 0 and strlen(all[2]) > max(0, _max_px):
                             all[2] = all[2][:-1]
                     else:
@@ -1099,9 +1108,9 @@ def list_mode(mini=False, half=False):
                 elif varinit.display.width <= 64:
                     offs = varinit.display.width - strlen(all[3])
                 else: offs = varinit.if_long - strlen(all[3])
-                if half: 
+                if half:
                     all[3] = all[3].replace(" " + if_not_clocktime,"")
-                    offs = 64 - strlen(all[3])
+                    offs = col_w - COL_MARGIN - strlen(all[3])
 
                     
 
@@ -1111,7 +1120,7 @@ def list_mode(mini=False, half=False):
 
                 if half: minsleft = minsleft.replace(" " + if_not_clocktime, "")
                 
-                if half: multiple_offset = (int(record) - 1) * 64
+                if half: multiple_offset = (int(record) - 1) * col_w
                 else: multiple_offset = 0
         
                 min_color = "white" if varinit.settings.get("listcolor_time", 0) or varinit.rotated else "yellow"
@@ -1125,7 +1134,7 @@ def list_mode(mini=False, half=False):
                         added_space = (_xs_max_lw + 2) * "("
                 elif mini:
                     added_space = varinit.settings["line_length"] * "(((("
-                    if half: added_space = line_col * "(" if multi_station_line_id else ""
+                    if half: added_space = COL_MARGIN * "(" + (line_col * "(" if multi_station_line_id else "")
                 else: added_space = varinit.settings["line_length"] * "(((((("
                 if not varinit.settings["line_length"]:
                     added_space = ""

--- a/apps/departures/web.py
+++ b/apps/departures/web.py
@@ -406,6 +406,21 @@ def html():
     # first so the [1][2][3] screen picker below makes sense
     mult_html = _chk("multiple", s["multiple"], "/?multiple=1", T["multiple"])
 
+    # station count (XL only: with 3 panels available, side-by-side lists
+    # can show either 2 or 3 stations; other devices always fill every
+    # panel they have, so there's nothing to pick). Reuses the existing
+    # /?width= endpoint, which already maps "x"/"xl" to settings["long"].
+    if if_long > 128:
+        _cur_width = "xl" if int(s.get("long", 0)) == 1 else "x"
+        mult_html += (
+            '<div class="toggle-row" id="stationcount" style="' + ("" if int(s["multiple"]) else "display:none;") + '">'
+            '<label for="station_count" class="toggle-label">Columns</label>'
+            '<select id="station_count" class="form-control" style="width:130px;display:inline" data-p="width" data-e="change">'
+            + _opt("x", _cur_width, "2 stations")
+            + _opt("xl", _cur_width, "3 stations")
+            + '</select></div>'
+        )
+
     # list mode
     listmode_html = ""
     if if_long > 64 and varinit.display.height <= 32:


### PR DESCRIPTION
- Always use full width when using multiple stations in list mode
- Support using 3 columns on XL display

Fixes #29 

---

**Current layout** (only supporting 2 columns)

<img width="1200" height="336" alt="IMG_7777" src="https://github.com/user-attachments/assets/f5e9d46c-1b9d-4d1f-a872-ea5cc699a659" />

**New layout** - 2 columns

<img width="1200" height="288" alt="IMG_7778" src="https://github.com/user-attachments/assets/e8ceb45d-f580-485f-bc27-e2288ec9c61a" />

**New layout** - 3 columns

<img width="1200" height="331" alt="IMG_7779" src="https://github.com/user-attachments/assets/014ac304-aacb-466e-9e21-8c846ad84674" />