### PR TITLE
fix: avoid using `(` as blank sentinel

### DIFF
--- a/lib/web_interface.py
+++ b/lib/web_interface.py
@@ -219,7 +219,7 @@ def _draw_progress(current, total, filename, error=False, label="installing"):
 
     # Draw filename on line 1 first (line=1 does NOT auto-refresh)
     name = filename.split("/")[-1]
-    pprint(name, 1, color="yellow" if not error else "red")
+    pprint(name, 1, color="yellow" if not error else "red", _refresh=False)
     # Draw progress bar (no refresh yet)
     bar_h = 4
     bar_y = h - bar_h - 9
@@ -823,28 +823,29 @@ def webinterface_post(request):
             #wifi.radio.connect(settings["ssid"], settings["password"])
         if "delete" in request.params:
             dir = request.params["delete"]
-            error_color = "green"
+            error_color = "white"
+            from load_screen import window
             try:
                 os.chdir(dir)
                 files = os.listdir()
                 total = len(files)
                 clearscreen(False)
+                window.fill(0)
                 for x, file in enumerate(files):
                     _draw_progress(x, total, file, label="deleting")
-                clearscreen(True)
-                for x, file in enumerate(files):
                     try:
                         os.remove(file)
                     except Exception as e:
                         error_color = "red"
                         print(e)
-                clearscreen(False)
                 _draw_progress(total, total, files[-1] if files else "", error_color == "red", label="deleting")
             finally:
                 os.chdir("/")
             try: os.rmdir(dir)
             except: pass
-            pprint("done!", color=error_color, line=-1, _refresh=True)
+            window.fill(0)
+            pprint("Done." if error_color != "red" else "Error!", 1, color=error_color, _clearscreen=True)
+            __main__.show_logo()
         if "install" in request.params:
             print(request.params["install"])
             install_app(request.params["install"])

--- a/lib/web_interface.py
+++ b/lib/web_interface.py
@@ -853,7 +853,6 @@ def webinterface_post(request):
             except: pass
             window.fill(0)
             pprint("Done." if error_color != "red" else "Error!", 1, color=error_color, _clearscreen=True)
-            __main__.show_logo()
         if "install" in request.params:
             print(request.params["install"])
             install_app(request.params["install"])

--- a/lib/web_interface.py
+++ b/lib/web_interface.py
@@ -831,14 +831,22 @@ def webinterface_post(request):
                 total = len(files)
                 clearscreen(False)
                 window.fill(0)
-                for x, file in enumerate(files):
-                    _draw_progress(x, total, file, label="deleting")
+                # Remove files with no drawing in between: os.remove() briefly
+                # halts execution for the flash write, and if that lands next
+                # to a display refresh it visibly glitches the panel. Record
+                # results here and replay real progress after, once all the
+                # flash writes are done.
+                failed = []
+                for file in files:
                     try:
                         os.remove(file)
+                        failed.append(False)
                     except Exception as e:
                         error_color = "red"
+                        failed.append(True)
                         print(e)
-                _draw_progress(total, total, files[-1] if files else "", error_color == "red", label="deleting")
+                for x, file in enumerate(files):
+                    _draw_progress(x + 1, total, file, failed[x], label="deleting")
             finally:
                 os.chdir("/")
             try: os.rmdir(dir)

--- a/lib/web_interface.py
+++ b/lib/web_interface.py
@@ -216,12 +216,10 @@ def _draw_progress(current, total, filename, error=False, label="installing"):
     from load_screen import window, pset, font_mini
     w = display.width
     h = display.height
-    #window.fill(0)
 
     # Draw filename on line 1 first (line=1 does NOT auto-refresh)
     name = filename.split("/")[-1]
-    pprint("("*128, 1, _clearscreen=False)
-    pprint(name, 1, _clearscreen=False, color="yellow" if not error else "red")
+    pprint(name, 1, color="yellow" if not error else "red")
     # Draw progress bar (no refresh yet)
     bar_h = 4
     bar_y = h - bar_h - 9


### PR DESCRIPTION
Since we're about to remove usage of `(` as a blank sentinel we should avoid using it for padding. By default, `pprint` sets `_clearscreen=True` which will clear the full row we're about to print on so there's no need to clear it first and instead we can just avoid setting `_clearscreen=False`.


https://github.com/user-attachments/assets/e28d7417-b3db-4e8d-a386-a688d77f7912

_Video is intentionally slow-ish, running in 5 fps for visibility_