### PR TITLE
feat: add remote canvas app

### DIFF
--- a/apps/remotecanvas/README.md
+++ b/apps/remotecanvas/README.md
@@ -1,0 +1,159 @@
+# Remote Canvas
+
+A minimal HTTP API for drawing on the device. Any device that can send a
+POST request can use it: a script, a CI job, a home automation hook,
+whatever you've got.
+
+Start the app, then open its page (or the device IP directly) for the live
+base URL and some copy-paste examples. It only holds 11 distinct colors at
+once (a palette limit of the LED panel), so requesting a 12th color evicts
+whichever one was used longest ago.
+
+This is meant for occasional redraws, not heavy or continuous drawing
+logic. Think a status readout, a notification, a dashboard tile that
+updates every few seconds or minutes. Every route runs synchronously and
+calls `refresh()` before returning, so each POST blocks until that frame is
+actually on the panel. There's no batching, no animation loop, no partial
+updates. Updating a scene means resending the whole thing, one request per
+shape, same as the examples below. It's a poor fit for anything driven at
+high frequency, like animations, games, or live meters.
+
+## Routes
+
+Colors are `#RRGGBB` hex strings. Drawing is additive, nothing gets cleared
+between calls, so send `/background` first if you want a clean frame.
+
+### `GET /info`
+
+```json
+{
+  "width": 64,
+  "height": 32
+}
+```
+
+### `POST /background`
+
+```json
+{
+  "color": "#003366"
+}
+```
+
+### `POST /pixel`
+
+```json
+{
+  "x": 5,
+  "y": 5,
+  "color": "#ffffff"
+}
+```
+
+### `POST /line`
+
+```json
+{
+  "x0": 2,
+  "y0": 2,
+  "x1": 20,
+  "y1": 10,
+  "color": "#ffffff"
+}
+```
+
+### `POST /rect`
+
+`border_color` and `fill_color` are both optional, but give at least one.
+
+```json
+{
+  "x0": 2,
+  "y0": 2,
+  "x1": 20,
+  "y1": 10,
+  "border_color": "#ffffff",
+  "fill_color": "#ff0000"
+}
+```
+
+### `POST /circle`
+
+`x`/`y` is the center. `border_color` and `fill_color` are both optional,
+but give at least one.
+
+```json
+{
+  "x": 16,
+  "y": 16,
+  "radius": 8,
+  "border_color": "#ffffff",
+  "fill_color": "#ff0000"
+}
+```
+
+### `POST /text`
+
+`x`/`y` place the text at an exact pixel and override `align`/`valign`
+entirely. `padding` nudges edge-aligned text inward (say `align: "left"`
+with `padding: 2` starts 2px in from the left edge); it has no effect when
+align or valign is `"center"`.
+
+```json
+{
+  "text": "Hello",
+  "font_size": "small",
+  "color": "#ffffff",
+  "align": "center",
+  "valign": "center",
+  "padding": 0
+}
+```
+
+## Example: an 80% battery icon
+
+Reads the panel size from `GET /info` so the battery centers correctly on
+any display, then draws a fixed size icon at the computed position. Replace
+`IP` with your device's address (shown on this app's `/` page).
+
+```bash
+INFO=$(curl -s http://$IP/info)
+WIDTH=$(echo "$INFO" | grep -o '"width": *[0-9]*' | grep -o '[0-9]*$')
+HEIGHT=$(echo "$INFO" | grep -o '"height": *[0-9]*' | grep -o '[0-9]*$')
+
+BODY_X0=$(( (WIDTH - 46) / 2 ))
+BODY_Y0=$(( 12 + ((HEIGHT - 12) - 13) / 2 ))
+BODY_X1=$(( BODY_X0 + 42 ))
+BODY_Y1=$(( BODY_Y0 + 12 ))
+NUB_X0=$(( BODY_X0 + 43 ))
+NUB_X1=$(( BODY_X0 + 45 ))
+NUB_Y0=$(( BODY_Y0 + 3 ))
+NUB_Y1=$(( BODY_Y0 + 9 ))
+
+curl -s http://$IP/background -d "{\"color\":\"#000000\"}"
+curl -s http://$IP/rect -d "{\"x0\":$BODY_X0,\"y0\":$BODY_Y0,\"x1\":$BODY_X1,\"y1\":$BODY_Y1,\"border_color\":\"#ffffff\",\"fill_color\":\"#000000\"}"
+curl -s http://$IP/rect -d "{\"x0\":$NUB_X0,\"y0\":$NUB_Y0,\"x1\":$NUB_X1,\"y1\":$NUB_Y1,\"fill_color\":\"#ffffff\"}"
+curl -s http://$IP/rect -d "{\"x0\":$((BODY_X0+2)),\"y0\":$NUB_Y0,\"x1\":$((BODY_X0+7)),\"y1\":$NUB_Y1,\"fill_color\":\"#00ff00\"}"
+curl -s http://$IP/rect -d "{\"x0\":$((BODY_X0+10)),\"y0\":$NUB_Y0,\"x1\":$((BODY_X0+15)),\"y1\":$NUB_Y1,\"fill_color\":\"#00ff00\"}"
+curl -s http://$IP/rect -d "{\"x0\":$((BODY_X0+18)),\"y0\":$NUB_Y0,\"x1\":$((BODY_X0+23)),\"y1\":$NUB_Y1,\"fill_color\":\"#00ff00\"}"
+curl -s http://$IP/rect -d "{\"x0\":$((BODY_X0+26)),\"y0\":$NUB_Y0,\"x1\":$((BODY_X0+31)),\"y1\":$NUB_Y1,\"fill_color\":\"#00ff00\"}"
+curl -s http://$IP/rect -d "{\"x0\":$((BODY_X0+34)),\"y0\":$NUB_Y0,\"x1\":$((BODY_X0+39)),\"y1\":$NUB_Y1,\"border_color\":\"#ffffff\"}"
+curl -s http://$IP/text -d '{"text":"80%","font_size":"large","color":"#ffffff","align":"center","valign":"top","padding":2}'
+```
+
+## Example: a flashing ERROR banner
+
+Flashes red with white text and white with red text five times, then
+clears back to black.
+
+```bash
+for i in $(seq 1 5); do
+  curl -s http://$IP/background -d '{"color":"#ff0000"}'
+  curl -s http://$IP/text -d '{"text":"ERROR!","font_size":"large","color":"#ffffff","align":"center","valign":"center"}'
+  sleep 0.3
+  curl -s http://$IP/background -d '{"color":"#ffffff"}'
+  curl -s http://$IP/text -d '{"text":"ERROR!","font_size":"large","color":"#ff0000","align":"center","valign":"center"}'
+  sleep 0.3
+done
+curl -s http://$IP/background -d '{"color":"#000000"}'
+```

--- a/apps/remotecanvas/__init__.py
+++ b/apps/remotecanvas/__init__.py
@@ -1,0 +1,2 @@
+from __main__ import *  # noqa: F403 # Kernel module
+import code  # noqa: F401

--- a/apps/remotecanvas/code.py
+++ b/apps/remotecanvas/code.py
@@ -1,0 +1,318 @@
+import json
+import math
+import sys
+
+import ampule
+import bitmaptools
+import wifi
+from check_button import check_if_button_pressed
+from load_screen import (
+    clearscreen,
+    display,
+    font_large,
+    font_mini,
+    font_small,
+    palette,
+    refresh,
+    strlen,
+    window,
+)
+from web_interface import footer, header
+
+from __main__ import socket
+
+exit_app = False
+w = display.width
+h = display.height
+
+FONTS = {"mini": font_mini, "small": font_small, "large": font_large}
+
+# Palette slots 0-11 are the only ones the kernel backs up/restores on app exit.
+# Slot 0 is pinned to black (matches window.fill(0) used everywhere else); the
+# other 11 slots are handed out to colors on a least-recently-used basis so an
+# arbitrary number of distinct hex colors can still be requested over time.
+COLOR_CACHE_SIZE = 11
+_color_slots = {}  # hex -> slot
+_color_lru = []  # hex values, oldest first
+
+
+def hex_to_rgb(value: str) -> tuple:
+    value = value.lstrip("#").lower()
+    if len(value) != 6:
+        return (255, 255, 255)
+
+    try:
+        return (int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16))
+    except ValueError:
+        return (255, 255, 255)
+
+
+def color_slot(value: str) -> int:
+    value = value.lstrip("#").lower()
+    if value in ("", "000000"):
+        return 0
+
+    if value in _color_slots:
+        _color_lru.remove(value)
+        _color_lru.append(value)
+        return _color_slots[value]
+
+    if len(_color_lru) < COLOR_CACHE_SIZE:
+        slot = len(_color_lru) + 1
+    else:
+        oldest = _color_lru.pop(0)
+        slot = _color_slots.pop(oldest)
+
+    palette[slot] = hex_to_rgb(value)
+    _color_slots[value] = slot
+    _color_lru.append(value)
+
+    return slot
+
+
+def circle_points(cx: int, cy: int, r: int):
+    """Midpoint circle algorithm; yields the 8-way symmetric outline points."""
+    x, y = r, 0
+    err = 0
+
+    while x >= y:
+        yield (cx + x, cy + y)
+        yield (cx + y, cy + x)
+        yield (cx - y, cy + x)
+        yield (cx - x, cy + y)
+        yield (cx - x, cy - y)
+        yield (cx - y, cy - x)
+        yield (cx + y, cy - x)
+        yield (cx + x, cy - y)
+
+        y += 1
+        if err <= 0:
+            err += 2 * y + 1
+        if err > 0:
+            x -= 1
+            err -= 2 * x + 1
+
+
+def draw_text(text: str, font: dict, slot: int, x0: int, y0: int) -> None:
+    is_mini = font is font_mini
+    fh = font["fontheight"]
+    px = 0
+
+    for ch in text:
+        lookup = ch.lower() if is_mini else ch
+        glyph = font.get(lookup, font.get("_"))
+        if glyph is None:
+            continue
+
+        gw = glyph[0]
+        for col in range(gw):
+            inv = gw - col
+            for row in range(fh):
+                if (glyph[row + 1] >> inv) & 1:
+                    x, y = x0 + px + col, y0 + row
+                    if 0 <= x < w and 0 <= y < h:
+                        window[x, y] = slot
+
+        px += gw
+
+
+with open("remotecanvas.html") as f:
+    html_body = f.read()
+
+
+@ampule.route("/exit", method="GET")
+def api_exit(request):
+    global exit_app
+    exit_app = True
+
+    return (200, {}, """<meta http-equiv="refresh" content="0; url=../" />""")
+
+
+@ampule.route("/", method="GET")
+def api_home(request):
+    ip = str(wifi.radio.ipv4_address) if wifi.radio.ipv4_address else "OFFLINE"
+    body = (
+        html_body.replace("__IP__", ip)
+        .replace("__WIDTH__", str(w))
+        .replace("__HEIGHT__", str(h))
+    )
+
+    return (200, {}, header("Remote Canvas", app=True) + body + footer())
+
+
+@ampule.route("/info", method="GET")
+def api_info(request):
+    return (
+        200,
+        {"Content-Type": "application/json"},
+        json.dumps({"width": w, "height": h}),
+    )
+
+
+@ampule.route("/background", method="POST")
+def api_background(request):
+    try:
+        data = json.loads(request.body)
+        slot = color_slot(str(data.get("color", "#000000")))
+        window.fill(slot)
+        refresh()
+    except Exception as e:
+        print("background err:", e)
+        return (400, {}, str(e))
+
+    return (200, {}, "ok")
+
+
+@ampule.route("/rect", method="POST")
+def api_rect(request):
+    try:
+        data = json.loads(request.body)
+        x0, x1 = sorted((int(data["x0"]), int(data["x1"])))
+        y0, y1 = sorted((int(data["y0"]), int(data["y1"])))
+        x0, y0 = max(x0, 0), max(y0, 0)
+        x1, y1 = min(x1, w - 1), min(y1, h - 1)
+
+        fill_color = data.get("fill_color")
+        if fill_color:
+            slot = color_slot(str(fill_color))
+            bitmaptools.fill_region(window, x0, y0, x1 + 1, y1 + 1, slot)
+
+        border_color = data.get("border_color")
+        if border_color:
+            slot = color_slot(str(border_color))
+            bitmaptools.draw_line(window, x0, y0, x1, y0, slot)
+            bitmaptools.draw_line(window, x0, y1, x1, y1, slot)
+            bitmaptools.draw_line(window, x0, y0, x0, y1, slot)
+            bitmaptools.draw_line(window, x1, y0, x1, y1, slot)
+
+        refresh()
+    except Exception as e:
+        print("rect err:", e)
+        return (400, {}, str(e))
+
+    return (200, {}, "ok")
+
+
+@ampule.route("/pixel", method="POST")
+def api_pixel(request):
+    try:
+        data = json.loads(request.body)
+        x, y = int(data["x"]), int(data["y"])
+        slot = color_slot(str(data.get("color", "#ffffff")))
+
+        if 0 <= x < w and 0 <= y < h:
+            window[x, y] = slot
+
+        refresh()
+    except Exception as e:
+        print("pixel err:", e)
+        return (400, {}, str(e))
+
+    return (200, {}, "ok")
+
+
+@ampule.route("/line", method="POST")
+def api_line(request):
+    try:
+        data = json.loads(request.body)
+        x0 = min(max(int(data["x0"]), 0), w - 1)
+        y0 = min(max(int(data["y0"]), 0), h - 1)
+        x1 = min(max(int(data["x1"]), 0), w - 1)
+        y1 = min(max(int(data["y1"]), 0), h - 1)
+        slot = color_slot(str(data.get("color", "#ffffff")))
+
+        bitmaptools.draw_line(window, x0, y0, x1, y1, slot)
+        refresh()
+    except Exception as e:
+        print("line err:", e)
+        return (400, {}, str(e))
+
+    return (200, {}, "ok")
+
+
+@ampule.route("/circle", method="POST")
+def api_circle(request):
+    try:
+        data = json.loads(request.body)
+        cx, cy = int(data["x"]), int(data["y"])
+        r = max(int(data["radius"]), 0)
+
+        fill_color = data.get("fill_color")
+        if fill_color:
+            slot = color_slot(str(fill_color))
+            for dy in range(-r, r + 1):
+                y = cy + dy
+                if not 0 <= y < h:
+                    continue
+
+                dx = int(math.sqrt(r * r - dy * dy))
+                x0 = max(cx - dx, 0)
+                x1 = min(cx + dx, w - 1)
+                if x0 <= x1:
+                    bitmaptools.draw_line(window, x0, y, x1, y, slot)
+
+        border_color = data.get("border_color")
+        if border_color:
+            slot = color_slot(str(border_color))
+            for x, y in circle_points(cx, cy, r):
+                if 0 <= x < w and 0 <= y < h:
+                    window[x, y] = slot
+
+        refresh()
+    except Exception as e:
+        print("circle err:", e)
+        return (400, {}, str(e))
+
+    return (200, {}, "ok")
+
+
+@ampule.route("/text", method="POST")
+def api_text(request):
+    try:
+        data = json.loads(request.body)
+        text = str(data.get("text", ""))
+        font = FONTS.get(data.get("font_size", "small"), font_small)
+        slot = color_slot(str(data.get("color", "#ffffff")))
+        fh = font["fontheight"]
+        tw = strlen(text, font)
+        padding = int(data.get("padding", 0))
+
+        if "x" in data:
+            x0 = int(data["x"])
+        else:
+            align = data.get("align", "left")
+            if align == "center":
+                x0 = max((w - tw) // 2, 0)
+            elif align == "right":
+                x0 = max(w - tw - padding, 0)
+            else:
+                x0 = padding
+
+        if "y" in data:
+            y0 = int(data["y"])
+        else:
+            valign = data.get("valign", "top")
+            if valign == "center":
+                y0 = max((h - fh) // 2, 0)
+            elif valign == "bottom":
+                y0 = max(h - fh - padding, 0)
+            else:
+                y0 = padding
+
+        draw_text(text, font, slot, x0, y0)
+        refresh()
+    except Exception as e:
+        print("text err:", e)
+        return (400, {}, str(e))
+
+    return (200, {}, "ok")
+
+
+clearscreen(lines=True)
+window.fill(0)
+refresh()
+
+while not exit_app:
+    ampule.listen(socket)
+    if check_if_button_pressed() == 2:
+        sys.exit()

--- a/apps/remotecanvas/code.py
+++ b/apps/remotecanvas/code.py
@@ -6,6 +6,7 @@ import ampule
 import bitmaptools
 import wifi
 from check_button import check_if_button_pressed
+from colors import hex_to_rgb
 from load_screen import (
     clearscreen,
     display,
@@ -34,17 +35,6 @@ FONTS = {"mini": font_mini, "small": font_small, "large": font_large}
 COLOR_CACHE_SIZE = 11
 _color_slots = {}  # hex -> slot
 _color_lru = []  # hex values, oldest first
-
-
-def hex_to_rgb(value: str) -> tuple:
-    value = value.lstrip("#").lower()
-    if len(value) != 6:
-        return (255, 255, 255)
-
-    try:
-        return (int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16))
-    except ValueError:
-        return (255, 255, 255)
 
 
 def color_slot(value: str) -> int:

--- a/apps/remotecanvas/remotecanvas.html
+++ b/apps/remotecanvas/remotecanvas.html
@@ -1,0 +1,99 @@
+<style>
+.page{max-width:560px}
+pre{background:var(--surface2);border:1px solid var(--border);border-radius:8px;padding:10px 12px;overflow-x:auto;font-size:.78rem;line-height:1.5;color:var(--text)}
+code{font-family:'Cascadia Mono','Fira Code','Consolas',monospace}
+.card h3{font-size:.85rem;margin-bottom:8px}
+.card p{font-size:.82rem;color:var(--muted);margin-bottom:8px}
+.route{display:inline-flex;align-items:center;gap:8px;margin-bottom:8px;font-family:'Cascadia Mono','Fira Code','Consolas',monospace}
+.verb{padding:2px 7px;border-radius:5px;font-weight:700;font-size:.68rem;letter-spacing:.4px}
+.verb-get{background:rgba(0,180,255,.15);color:#4fc3f7}
+.verb-post{background:rgba(0,200,120,.15);color:#3ddc84}
+.path{font-size:.82rem;color:var(--text)}
+</style>
+
+<h2>Remote Canvas</h2>
+<p style="color:var(--muted);font-size:.82rem;margin:4px 0 14px">
+Any device on the network can POST JSON to this app to draw on the
+__WIDTH__x__HEIGHT__ matrix. Base URL: <code>http://__IP__/</code>
+</p>
+
+<div class="card">
+<h3>Set background</h3>
+<p>Fills the whole display with one color.</p>
+<div class="route"><span class="verb verb-post">POST</span><span class="path">/background</span></div>
+<pre>{
+  "color": "#003366"
+}</pre>
+</div>
+
+<div class="card">
+<h3>Draw pixel</h3>
+<div class="route"><span class="verb verb-post">POST</span><span class="path">/pixel</span></div>
+<pre>{
+  "x": 5,
+  "y": 5,
+  "color": "#ffffff"
+}</pre>
+</div>
+
+<div class="card">
+<h3>Draw line</h3>
+<div class="route"><span class="verb verb-post">POST</span><span class="path">/line</span></div>
+<pre>{
+  "x0": 2,
+  "y0": 2,
+  "x1": 20,
+  "y1": 10,
+  "color": "#ffffff"
+}</pre>
+</div>
+
+<div class="card">
+<h3>Draw rect</h3>
+<p>Coordinates are inclusive pixel positions. Include either or both colors.</p>
+<div class="route"><span class="verb verb-post">POST</span><span class="path">/rect</span></div>
+<pre>{
+  "x0": 2,
+  "y0": 2,
+  "x1": 20,
+  "y1": 10,
+  "border_color": "#ffffff",
+  "fill_color": "#ff0000"
+}</pre>
+</div>
+
+<div class="card">
+<h3>Draw circle</h3>
+<p>x/y is the center. Include either or both colors.</p>
+<div class="route"><span class="verb verb-post">POST</span><span class="path">/circle</span></div>
+<pre>{
+  "x": 16,
+  "y": 16,
+  "radius": 8,
+  "border_color": "#ffffff",
+  "fill_color": "#ff0000"
+}</pre>
+</div>
+
+<div class="card">
+<h3>Draw text</h3>
+<p>font_size is one of "mini", "small", "large". Give x/y for an exact
+position, or align/valign with an optional padding (ignored on "center").</p>
+<div class="route"><span class="verb verb-post">POST</span><span class="path">/text</span></div>
+<pre>{
+  "text": "Hello",
+  "font_size": "small",
+  "color": "#ffffff",
+  "align": "center",
+  "valign": "center"
+}</pre>
+</div>
+
+<div class="card">
+<h3>Display info</h3>
+<div class="route"><span class="verb verb-get">GET</span><span class="path">/info</span></div>
+<pre>{
+  "width": __WIDTH__,
+  "height": __HEIGHT__
+}</pre>
+</div>

--- a/apps/remotecanvas/v0.1
+++ b/apps/remotecanvas/v0.1
@@ -1,0 +1,5 @@
+{
+  "description":"Draw on your device remote",
+  "emoji":"🛜"
+}
+

--- a/lib/colors.py
+++ b/lib/colors.py
@@ -1,0 +1,9 @@
+def hex_to_rgb(value: str) -> tuple:
+    value = value.lstrip("#").lower()
+    if len(value) != 6:
+        return (255, 255, 255)
+
+    try:
+        return (int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16))
+    except ValueError:
+        return (255, 255, 255)

--- a/repository.txt
+++ b/repository.txt
@@ -17,6 +17,7 @@
     "lib/font_large.py",
     "lib/ai_agent.py",
     "lib/cmd.py",
-    "lib/filemanager.py"
+    "lib/filemanager.py",
+    "lib/colors.py"
   ]
 }


### PR DESCRIPTION
App that serves HTTP interface so you can draw remotely on the device

Any device on the network can POST JSON to it to draw on the device:
set the background, place pixels, lines, rects and circles, and write
text with alignment, padding, or exact x/y placement. It's built for
occasional redraws like a status readout or a notification, not
continuous animation.

---

## Screenshots

### App view interface

<img width="1063" height="1239" alt="settings" src="https://github.com/user-attachments/assets/620a589f-fead-4c91-8c9a-fd336b902995" />

### First example from README (battery)

<img width="1025" height="256" alt="battery" src="https://github.com/user-attachments/assets/298d4faa-fdb7-409e-ae88-1b87f8d8d871" />

### Second example from README (last frame)

<img width="1024" height="257" alt="error" src="https://github.com/user-attachments/assets/c5cabc0a-fb87-468f-8ced-cd807a1a0535" />